### PR TITLE
静的解析導入

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,8 +21,21 @@ linter:
   # `// ignore_for_file: name_of_lint` syntax on the line or in the file
   # producing the lint.
   rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+    prefer_single_quotes: true
+    always_declare_return_types: true
+    avoid_print: true
+    avoid_empty_else: true
+    avoid_return_types_on_setters: true
+    prefer_const_constructors: true
+    prefer_final_locals: true
+    unnecessary_this: true
+    use_key_in_widget_constructors: true
+
+analyzer:
+  exclude:
+    - build/**
+    - .dart_tool/**
+    - "**/*.g.dart"
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/lib/screens/gallery/gallery_screen.dart
+++ b/lib/screens/gallery/gallery_screen.dart
@@ -104,7 +104,7 @@ class _GalleryScreenState extends State<GalleryScreen>
     
     Future.delayed(const Duration(milliseconds: 50), () {
       if (!mounted || !_controller.hasClients) return;
-      // レイアウト計算後に再度チェックし、スクロール可能なら一番下に移動
+      // レイアウト計算後に再度チェックし、スクロール可能なら一番下に移動lib/screens/viewer/widgets/info_sheet.dart:1:8
       if (_controller.position.maxScrollExtent > 0.0) {
         _controller.jumpTo(_controller.position.maxScrollExtent);
       }

--- a/lib/screens/gallery/gallery_screen.dart
+++ b/lib/screens/gallery/gallery_screen.dart
@@ -104,7 +104,7 @@ class _GalleryScreenState extends State<GalleryScreen>
     
     Future.delayed(const Duration(milliseconds: 50), () {
       if (!mounted || !_controller.hasClients) return;
-      // レイアウト計算後に再度チェックし、スクロール可能なら一番下に移動lib/screens/viewer/widgets/info_sheet.dart:1:8
+      // レイアウト計算後に再度チェックし、スクロール可能なら一番下に移動
       if (_controller.position.maxScrollExtent > 0.0) {
         _controller.jumpTo(_controller.position.maxScrollExtent);
       }

--- a/lib/screens/viewer/widgets/info_sheet.dart
+++ b/lib/screens/viewer/widgets/info_sheet.dart
@@ -1,4 +1,3 @@
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';


### PR DESCRIPTION
# やったこと
- 静的解析導入

# 今後実装予定
- Album内写真一覧画面にて写真の枚数が中途半端のとききれいに配置されない
- 新しい写真があった場合再読込する

## 詳細画面系
- 削除時一つ古い写真・動画に遷移
- Exifを細かく（どんな端末で・焦点距離・ISO・F値・シャッタースピード・ピクセル横×縦・動画の場合フレームレート）
- サムネイルを下部に出してスライドできるようにする

## 一覧画面系
- 削除時一番下に行く問題修正
- 共有時選択が解除されてない
- 新しい画像の再読み込み